### PR TITLE
Add support for a "data text" archive

### DIFF
--- a/src/installerquick.h
+++ b/src/installerquick.h
@@ -33,6 +33,7 @@ public:
 private:
 
   bool isSimpleArchiveTopLayer(const MOBase::DirectoryTree::Node *node) const;
+  bool isDataTextArchiveTopLayer(const MOBase::DirectoryTree::Node *node) const;
   const MOBase::DirectoryTree::Node *getSimpleArchiveBase(const MOBase::DirectoryTree &dataTree) const;
 
 private:


### PR DESCRIPTION
A "data text" archive is defined as having a a directory that contains exactly one folder named "data" and one or more text files.  The data folder will be selected as the mod's data directory.  The text files will be moved into the data directory.