### PR TITLE
Fix issue where 'fixer' is not initialized

### DIFF
--- a/src/installerquick.cpp
+++ b/src/installerquick.cpp
@@ -133,7 +133,8 @@ InstallerQuick::install(GuessedValue<QString>& modName,
 
   auto base = std::const_pointer_cast<IFileTree>(
       getSimpleArchiveBase(tree, dataFolderName, checker.get()));
-  if (base == nullptr) {
+  if (base == nullptr &&
+      checker->dataLooksValid(tree) == ModDataChecker::CheckReturn::FIXABLE) {
     tree = checker->fix(tree);
   } else {
     tree = base;


### PR DESCRIPTION
- getSimpleArchiveBase crawls every directory until it finds a 'VALID' or runs out of directories
- Even if the archive as a whole is 'fixable', the fixer gets unset if the last entry is not 'fixable'
- isArchiveSupported still sees the base 'fixable' response and tells MO2 the archive is installable
- install uses 'getSimpleArchiveBase' to init the process, causing 'checker' to be set null
- rerunning the 'dataLooksValid' on the base archive before running 'fix' corrects the issue